### PR TITLE
fix(domain): assetPrefix is prefixed by "//" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,16 @@ Specifies the retry domain when assets fail to load. In the `domain` array, the 
 For example:
 
 ```js
-pluginAssetsRetry({
-  domain: ["https://cdn1.com", "https://cdn2.com", "https://cdn3.com"],
+// rsbuild.config.ts
+defineConfig({
+  plugins: [
+    pluginAssetsRetry({
+      domain: ["https://cdn1.com", "https://cdn2.com", "https://cdn3.com"],
+    })
+  ],
+  output: {
+    assetPrefix: "https://cdn1.com",
+  }
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ defineConfig({
   ],
   output: {
     assetPrefix: "https://cdn1.com",
-  }
+  },
 });
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -101,11 +101,11 @@ const defaultOptions = {
 defineConfig({
   plugins: [
     pluginAssetsRetry({
-      domain: ["cdn1.com", "cdn2.com", "cdn3.com"],
+      domain: ["https://cdn1.com", "https://cdn2.com", "https://cdn3.com"],
     })
   ],
   output: {
-    assetPrefix: "//cdn1.com",
+    assetPrefix: "https://cdn1.com",
   },
 });
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -97,8 +97,16 @@ const defaultOptions = {
 比如：
 
 ```js
-pluginAssetsRetry({
-  domain: ["https://cdn1.com", "https://cdn2.com", "https://cdn3.com"],
+// rsbuild.config.ts
+defineConfig({
+  plugins: [
+    pluginAssetsRetry({
+      domain: ["cdn1.com", "cdn2.com", "cdn3.com"],
+    })
+  ],
+  output: {
+    assetPrefix: "//cdn1.com",
+  },
 });
 ```
 

--- a/src/runtime/asyncChunkRetry.ts
+++ b/src/runtime/asyncChunkRetry.ts
@@ -140,13 +140,13 @@ function initRetry(chunkId: string, isCssAsyncChunk: boolean): Retry {
   }
 
   const originalPublicPath = __RUNTIME_GLOBALS_PUBLIC_PATH__;
-  const originalSrcUrl = originalPublicPath.startsWith('/')
+  const originalSrcUrl = originalPublicPath.startsWith('/') && !(originalPublicPath.startsWith('//'))
     ? window.origin + originalPublicPath + originalScriptFilename
     : originalPublicPath + originalScriptFilename;
   const originalQuery = getQueryFromUrl(originalSrcUrl);
 
   const existRetryTimes = 0;
-  const nextDomain = config.domain?.[0] || window.origin;
+  const nextDomain = findCurrentDomain(originalSrcUrl);
 
   return {
     nextDomain,

--- a/src/runtime/asyncChunkRetry.ts
+++ b/src/runtime/asyncChunkRetry.ts
@@ -140,9 +140,10 @@ function initRetry(chunkId: string, isCssAsyncChunk: boolean): Retry {
   }
 
   const originalPublicPath = __RUNTIME_GLOBALS_PUBLIC_PATH__;
-  const originalSrcUrl = originalPublicPath.startsWith('/') && !(originalPublicPath.startsWith('//'))
-    ? window.origin + originalPublicPath + originalScriptFilename
-    : originalPublicPath + originalScriptFilename;
+  const originalSrcUrl =
+    originalPublicPath[0] === '/' && originalPublicPath[1] !== '/'
+      ? window.origin + originalPublicPath + originalScriptFilename
+      : originalPublicPath + originalScriptFilename;
   const originalQuery = getQueryFromUrl(originalSrcUrl);
 
   const existRetryTimes = 0;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -112,3 +112,40 @@ test('should work when the first, second cdn are all failed and the third is suc
   await expect(compTestElement).toHaveText('Hello AsyncCompTest');
   await expect(compTestElement).toHaveCSS('background-color', 'rgb(0, 0, 139)');
 });
+
+
+test('should work when the first, second cdn are all failed and the third is success, domain is prefixed with //', async ({
+  page,
+}) => {
+  // this is a real world case for assets-retry
+  const port = await getRandomPort();
+  const rsbuild = await createRsbuildWithMiddleware(
+    [],
+    {
+      minify: true,
+      domain: [
+        'a.com/foo-path',
+        'b.com',
+        `localhost:${port}`,
+      ],
+      addQuery: true,
+      onRetry(context) {
+        console.info('onRetry', context);
+      },
+      onSuccess(context) {
+        console.info('onSuccess', context);
+      },
+      onFail(context) {
+        console.info('onFail', context);
+      },
+    },
+    undefined,
+    port,
+    '//a.com/foo-path',
+  );
+
+  await gotoPage(page, rsbuild);
+  const compTestElement = page.locator('#async-comp-test');
+  await expect(compTestElement).toHaveText('Hello AsyncCompTest');
+  await expect(compTestElement).toHaveCSS('background-color', 'rgb(0, 0, 139)');
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -113,7 +113,6 @@ test('should work when the first, second cdn are all failed and the third is suc
   await expect(compTestElement).toHaveCSS('background-color', 'rgb(0, 0, 139)');
 });
 
-
 test('should work when the first, second cdn are all failed and the third is success, domain is prefixed with //', async ({
   page,
 }) => {
@@ -123,11 +122,7 @@ test('should work when the first, second cdn are all failed and the third is suc
     [],
     {
       minify: true,
-      domain: [
-        'a.com/foo-path',
-        'b.com',
-        `localhost:${port}`,
-      ],
+      domain: ['a.com/foo-path', 'b.com', `localhost:${port}`],
       addQuery: true,
       onRetry(context) {
         console.info('onRetry', context);


### PR DESCRIPTION
```ts
// rsbuild.config.ts
defineConfig({
	plugins: [pluginAssetsRetry({
      minify: true,
      domain: ['a.com/foo-path', 'b.com', `localhost:${port}`],
      addQuery: true,
      onRetry(context) {
        console.info('onRetry', context);
      },
      onSuccess(context) {
        console.info('onSuccess', context);
      },
      onFail(context) {
        console.info('onFail', context);
      },
    })],
    output: {
		assetPrefix: '//a.com/foo-path',
    },
 })
```

expected

`http://a.com/foo-path/static/css/async/src_AsyncCompTest_tsx.css?retry=1`

actual

`http://localhost:38493//a.com/foo-path/static/css/async/src_AsyncCompTest_tsx.css?retry=1`