### PR TITLE
fix!: remove sync script retry and `document.write` for white screen security

### DIFF
--- a/src/runtime/asyncChunkRetry.ts
+++ b/src/runtime/asyncChunkRetry.ts
@@ -1,3 +1,4 @@
+import { ERROR_PREFIX } from './contants.js';
 import {
   findCurrentDomain,
   findNextDomain,
@@ -173,8 +174,6 @@ const originalGetCssFilename =
   __RUNTIME_GLOBALS_GET_CSS_FILENAME__ ||
   (() => null);
 const originalLoadScript = __RUNTIME_GLOBALS_LOAD_SCRIPT__;
-
-const ERROR_PREFIX = '[@rsbuild/plugin-assets-retry] ';
 
 // if users want to support es5, add Promise polyfill first https://github.com/webpack/webpack/issues/12877
 function ensureChunk(chunkId: string): Promise<unknown> {

--- a/src/runtime/contants.ts
+++ b/src/runtime/contants.ts
@@ -1,0 +1,1 @@
+export const ERROR_PREFIX = '[@rsbuild/plugin-assets-retry] ';

--- a/src/runtime/initialChunkRetry.ts
+++ b/src/runtime/initialChunkRetry.ts
@@ -1,4 +1,5 @@
 // rsbuild/runtime/initial-chunk-retry
+import { ERROR_PREFIX } from './contants.js';
 import {
   findCurrentDomain,
   findNextDomain,
@@ -31,18 +32,9 @@ function getRequestUrl(element: HTMLElement) {
     element instanceof HTMLScriptElement ||
     element instanceof HTMLImageElement
   ) {
-    // For <script src="" /> or <img src="" />
-    // element.getAttribute('src') === '' but element.src === baseURI
-    if (!element.getAttribute('src')?.trim()) {
-      return null;
-    }
     return element.src;
   }
   if (element instanceof HTMLLinkElement) {
-    // For <link href="" />
-    if (!element.getAttribute('href')?.trim()) {
-      return null;
-    }
     return element.href;
   }
   return null;
@@ -148,7 +140,11 @@ function reloadElementResource(
     if (attributes.isAsync) {
       document.body.appendChild(fresh.element);
     } else {
-      document.write(fresh.str);
+      console.warn(
+        ERROR_PREFIX,
+        'load sync script failed, for security only async/defer script can be retried',
+        origin,
+      );
     }
   }
 


### PR DESCRIPTION
https://github.com/Nikaple/assets-retry/blob/d863b9154d322b04621f67d75fc1358892bec560/src/util.ts#L145

If we support synchronous resource retry, we will use document.write

This is a very dangerous API that can cause the page to go white screen if it is executed after the page is loaded

 Each browser manufacturer has different behavior for document.write.