### PR TITLE
docs: add description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@rsbuild/plugin-assets-retry",
   "version": "1.4.2",
+  "description": "An Rsbuild plugin to automatically resend requests when static assets fail to load.",
   "repository": "https://github.com/rspack-contrib/rsbuild-plugin-assets-retry",
   "license": "MIT",
   "type": "module",
@@ -17,19 +18,19 @@
   "files": ["dist"],
   "scripts": {
     "build": "rslib build",
+    "bump": "npx bumpp",
     "dev": "rslib build --watch",
     "lint": "biome check .",
     "lint:write": "biome check . --write",
     "prepare": "simple-git-hooks && npm run build",
-    "test": "playwright test",
-    "bump": "npx bumpp"
+    "test": "playwright test"
   },
   "simple-git-hooks": {
     "pre-commit": "npm run lint:write"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.52.10",
     "@biomejs/biome": "^1.9.4",
+    "@microsoft/api-extractor": "^7.52.10",
     "@playwright/test": "^1.54.1",
     "@rsbuild/core": "^1.5.0-beta.1",
     "@rsbuild/plugin-react": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "pre-commit": "npm run lint:write"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "^7.52.13",
     "@biomejs/biome": "^1.9.4",
+    "@microsoft/api-extractor": "^7.52.13",
     "@playwright/test": "^1.55.0",
     "@rsbuild/core": "^1.5.7",
     "@rsbuild/plugin-react": "^1.4.0",


### PR DESCRIPTION
Add plugin description to package.json to clarify its purpose and functionality.

Fix:

<img width="1308" height="266" alt="image" src="https://github.com/user-attachments/assets/e0982250-d009-4ba2-8859-173b2d85d21f" />
